### PR TITLE
feat(resize): the force option make a crop to fit the new size

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -107,7 +107,7 @@ export default callbackRuntime(async (event: APIGatewayEvent) => {
       stream.resize(config.resize.width, config.resize.height)
 
       if (config.resize.force) {
-        stream.ignoreAspectRatio()
+        stream.crop()
       } else {
         stream.max()
       }


### PR DESCRIPTION
This fork is a proposal for my own point of view about how must the "force" flag work.

Instead of modify the aspect ratio of the image, when the "force" flag is specified, it makes a graceful crop form the center of the image.